### PR TITLE
chore(package): Use descriptive keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,18 @@
   "homepage": "https://github.com/stoplightio/vscode-spectral",
   "icon": "icon.png",
   "keywords": [
-    "multi-root ready"
+    "linter",
+    "validator",
+    "OpenAPI",
+    "Swagger",
+    "API",
+    "style guide",
+    "API description",
+    "API specification",
+    "OAS",
+    "OAS2",
+    "OAS3",
+    "AsyncAPI"
   ],
   "license": "Apache-2.0",
   "main": "./client/index.js",


### PR DESCRIPTION
@philsturgeon This brings back the initial keywords to enrich the current marketplace tags view 

![image](https://user-images.githubusercontent.com/92363/87512859-0b871a00-c678-11ea-9c09-706675258bc1.png)
