### PR TITLE
v0.2.2 - Minor tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2020-07-17
+
+- Fixed
+
+  - Properly register "Show Output Channel" command
+  - Use a more complete list of keywords to describe the extension
+  - Minor tweaks to the build/release pipeline
+
 ## [0.2.1] - 2020-07-14
 
 - Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spectral Linter for VS Code
 
+[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/stoplight.spectral.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=stoplight.spectral)
+
 The Spectral VS Code Extension brings the power of [Spectral](https://stoplight.io/open-source/spectral?utm_source=referral&utm_medium=marketplace&utm_campaign=vscode_extension) to your favorite editor.
 
 Spectral is a flexible object linter with out of the box support for [OpenAPI](https://openapis.org/) v2 and v3.

--- a/package.json
+++ b/package.json
@@ -67,15 +67,15 @@
       },
       "title": "Spectral",
       "type": "object"
-    }
+    },
+    "commands": [
+      {
+        "title": "Show Output Channel",
+        "category": "Spectral",
+        "command": "spectral.showOutputChannel"
+      }
+    ]
   },
-  "commands": [
-    {
-      "title": "Show Output Channel",
-      "category": "Spectral",
-      "command": "spectral.showOutputChannel"
-    }
-  ],
   "description": "JSON/YAML linter with OpenAPI and custom ruleset support.",
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -145,5 +145,5 @@
     "test:e2e": "cross-env CI=true CHAI_JEST_SNAPSHOT_UPDATE_ALL=false node ./client/out/test/e2e/index.js",
     "watch": "tsc -b -w"
   },
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   "license": "Apache-2.0",
   "main": "./client/index.js",
   "name": "spectral",
+  "preview": true,
   "publisher": "stoplight",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- "Spectral: Show Output Channel" palette command makes it easier to access logs when something bad happens (Hit Ctrl+Shift+P, then start typing "Spectral")
- The Preview flag visually advertizes that this is an unstable extension
- Display a the latest published version on the README