### PR TITLE
chore(build): use latest xvfb-action version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
         run: yarn install
 
       - name: Build, lint, test and package
-        # Stuck on v1.0  because of https://github.com/GabrielBB/xvfb-action/issues/10
-        uses: GabrielBB/xvfb-action@v1.0
+        uses: GabrielBB/xvfb-action@v1
         with:
           run: node make.js allDev


### PR DESCRIPTION
Now that https://github.com/GabrielBB/xvfb-action/issues/10 has been merged

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
