### PR TITLE
Release v0.2.4 - Spectral 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2020-10-06
+
+### Changed
+
+- Update to Spectral v5.6.0
+
 ## [0.2.3] - 2020-09-11
 
-- Changed
+### Changed
 
-  - Update to latest stable Spectral v5.5.0
-  - Update other dependencies
-  - Minor tweaks to the build/release pipeline
+- Update to Spectral v5.5.0
+- Update other dependencies
+- Minor tweaks to the build/release pipeline
 
 ## [0.2.2] - 2020-07-17
 
-- Fixed
+### Fixed
 
-  - Properly register "Show Output Channel" command
-  - Use a more complete list of keywords to describe the extension
-  - Minor tweaks to the build/release pipeline
+- Properly register "Show Output Channel" command
+- Use a more complete list of keywords to describe the extension
+- Minor tweaks to the build/release pipeline
 
 ## [0.2.1] - 2020-07-14
 
-- Fixed
+### Fixed
 
-  - Fix dead link on the README page
-  - Make Spectral link point to stoplight.io website
+- Fix dead link on the README page
+- Make Spectral link point to stoplight.io website
 
 ## [0.2.0] - 2020-07-14
 
@@ -34,10 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Display the changelog in the extension details pane
 
-- Changed
+### Changed
 
-  - Leverage the Language Server Protocol to remove the actual linting operation from the UI thread
-  - Upgrade to Spectral v5.5.0-beta8, leveraging `nimma` rule optimizer
+- Leverage the Language Server Protocol to remove the actual linting operation from the UI thread
+- Upgrade to Spectral v5.5.0-beta8, leveraging `nimma` rule optimizer
 
 ## [0.1.0] - 2020-04-10
 

--- a/README.md
+++ b/README.md
@@ -4,42 +4,42 @@
 
 The Spectral VS Code Extension brings the power of [Spectral](https://stoplight.io/open-source/spectral?utm_source=referral&utm_medium=marketplace&utm_campaign=vscode_extension) to your favorite editor.
 
-Spectral is a flexible object linter with out of the box support for [OpenAPI](https://openapis.org/) v2 and v3.
+Spectral is a flexible object linter with out of the box support for [OpenAPI](https://openapis.org/) v2 and v3, JSON Schema, and AsyncAPI.
 
 ## Features
 
-* Lint-on-save
-* Lint-on-type
-* Custom ruleset support (`spectral` or `.spectral` files with `.json`, `.yaml` or `.yml` extensions)
-* Intellisense for custom ruleset editing
-* Support for JSON and YAML input
+- Lint-on-save
+- Lint-on-type
+- Custom ruleset support (`.spectral.json`, `.spectral.yaml` or `.spectral.yml`)
+- Intellisense for custom ruleset editing
+- Support for JSON and YAML input
 
 ![screenshot](assets/screenshot1.png)
 
 ## Requirements
 
-* Node.js 12.13 or higher
-* Visual Studio Code version 1.48 or higher.
+- Node.js 12.13 or higher
+- Visual Studio Code version 1.48 or higher.
 
 ## Installation
 
-* Install from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=stoplight.spectral)
-* Install via the CLI: `code --install-extension stoplight.spectral`
+- Install from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=stoplight.spectral)
+- Install via the CLI: `code --install-extension stoplight.spectral`
 
 ## Extension Settings
 
 This extension contributes the following settings:
 
-* `spectral.enable`: Controls whether or not Spectral is enabled.
-* `spectral.rulesetFile`: Location of the ruleset file to use when validating. If omitted, the default is a `.spectral.yml`/`.spectral.json` in the same folder as the document being validated. Paths are relative to the workspace.
-* `spectral.run`: Run the linter on save (`onSave`) or as you type (`onType`).
-* `spectral.validateFiles`: An array of file globs (e.g., `**/*.yaml`) which should be validated by Spectral. If language identifiers are also specified, the file must match both in order to be validated.
-* `spectral.validateLanguages`: An array of language IDs (e.g., `yaml`, `json`) which should be validated by Spectral. If file globs are also specified, the file must match both in order to be validated.
+- `spectral.enable`: Controls whether or not Spectral is enabled.
+- `spectral.rulesetFile`: Location of the ruleset file to use when validating. If omitted, the default is a `.spectral.(json|yaml|yml)` in the same folder as the document being validated. Paths are relative to the workspace.
+- `spectral.run`: Run the linter on save (`onSave`) or as you type (`onType`).
+- `spectral.validateFiles`: An array of file globs (e.g., `**/*.yaml`) which should be validated by Spectral. If language identifiers are also specified, the file must match both in order to be validated.
+- `spectral.validateLanguages`: An array of language IDs (e.g., `yaml`, `json`) which should be validated by Spectral. If file globs are also specified, the file must match both in order to be validated.
 
 ## Thanks
 
-* [Mike Ralphson](https://github.com/MikeRalphson)
-* [Travis Illig](https://github.com/tillig)
+- [Mike Ralphson](https://github.com/MikeRalphson)
+- [Travis Illig](https://github.com/tillig)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@types/chai-jest-snapshot": "^1.3.6",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.3",
-    "@types/node": "^12.12.56",
+    "@types/node": "^14.11.0",
     "@types/vscode": "^1.48.0",
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
@@ -94,7 +94,7 @@
     "eslint-config-google": "^0.14.0",
     "glob": "^7.1.6",
     "jsonpath": "^1.0.2",
-    "merge-options": "^2.0.0",
+    "merge-options": "^3.0.0",
     "mocha": "^8.1.3",
     "rimraf": "^3.0.2",
     "semver": "^7.3.2",
@@ -145,7 +145,7 @@
     "test:e2e": "cross-env CI=true CHAI_JEST_SNAPSHOT_UPDATE_ALL=false node ./client/out/test/e2e/index.js",
     "watch": "tsc -b -w"
   },
-  "version": "0.2.3",
+  "version": "0.2.4",
   "workspaces": {
     "packages": [
       "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Stoplight <support@stoplight.io>",
   "dependencies": {
-    "@stoplight/spectral": "^5.5.0",
+    "@stoplight/spectral": "^5.6.0",
     "minimatch": "^3.0.4",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,10 +228,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
   integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
-"@types/node@^12.12.56":
-  version "12.12.56"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.56.tgz#83591a89723d8ec3eaf722137e1784a7351edb6c"
-  integrity sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ==
+"@types/node@^14.11.0":
+  version "14.11.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.5.tgz#fecad41c041cae7f2404ad4b2d0742fdb628b305"
+  integrity sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==
 
 "@types/urijs@^1.19.9":
   version "1.19.12"
@@ -2658,7 +2658,7 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-obj@^2.0.0:
+is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
@@ -3032,12 +3032,12 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-merge-options@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-2.0.0.tgz#36ca5038badfc3974dbde5e58ba89d3df80882c3"
-  integrity sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==
+merge-options@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.3.tgz#802b401f0de8dfae00d2a1e2dab9759b3dd98fe4"
+  integrity sha512-jytfjQxL5mVrtD9O24zOXU4neV3uVbQdn1F0o1pzSa1yH9LTEUOtfwpWSsyAxrrrXqAFTxaU4ynqkmekHLvYew==
   dependencies:
-    is-plain-obj "^2.0.0"
+    is-plain-obj "^2.1.0"
 
 merge2@^1.3.0:
   version "1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,12 +102,11 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
-"@stoplight/lifecycle@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/lifecycle/-/lifecycle-2.3.0.tgz#072036efe0984e52502449172373b7f427c85954"
-  integrity sha512-nVeciLEYlj97W4OEwGp7UVGzdTkux8mSacbAARPJboEvVrqW/QHfAc830rcZ/UBvpWuni5WbMAPFpQ9t9Jb/AA==
+"@stoplight/lifecycle@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/lifecycle/-/lifecycle-2.3.1.tgz#9cb0b2e260e3d4a52a14f7a92403807ee2c2b53f"
+  integrity sha512-On7qGYPDG1sgx2AOuJp8Hmm6WdK8+1PpCs7DEYoJ1GWtruPij9Q/pW0AV9CuR8KbCrOnvYcBsplaanB+Q3g/7Q==
   dependencies:
-    strict-event-emitter-types "^2.0.0"
     wolfy87-eventemitter "~5.2.8"
 
 "@stoplight/ordered-object-literal@^1.0.1":
@@ -120,16 +119,16 @@
   resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.3.2.tgz#96e591496b72fde0f0cdae01a61d64f065bd9ede"
   integrity sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==
 
-"@stoplight/spectral@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.5.0.tgz#5fe80e993ee639e8e448510186eb54908469263b"
-  integrity sha512-2TtADRz9yNhBs4m7p9Y25VX/5aoZPNETWRFo14A/a9Tu4oPFmJojJO1FFhk8Hu2kjKHtZeB4zXVuvtmbq/fPtQ==
+"@stoplight/spectral@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.6.0.tgz#b69efc2d32bb7db5f165339a3131d9bb619c5e98"
+  integrity sha512-BLHAC/J56njpju3Z7TY9VMBbTxo4nY/WK7a3s5tYxIY6rOvNeS+qne3xK14qWnk4FS/gxAkVH9s1wZDWh/SVlw==
   dependencies:
     "@stoplight/better-ajv-errors" "0.0.0"
     "@stoplight/json" "3.9.0"
     "@stoplight/json-ref-readers" "1.2.1"
     "@stoplight/json-ref-resolver" "3.1.0"
-    "@stoplight/lifecycle" "2.3.0"
+    "@stoplight/lifecycle" "2.3.1"
     "@stoplight/path" "1.3.2"
     "@stoplight/types" "^11.9.0"
     "@stoplight/yaml" "4.2.1"
@@ -139,6 +138,7 @@
     blueimp-md5 "2.13.0"
     chalk "4.0.0"
     eol "0.9.1"
+    expression-eval "3.1.2"
     fast-glob "3.1.0"
     jsonpath-plus "4.0.0"
     lodash "4.17.19"
@@ -1874,6 +1874,13 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
+expression-eval@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/expression-eval/-/expression-eval-3.1.2.tgz#45ddf0b8fdb8bf0633d02f4061d6f25516eddb30"
+  integrity sha512-c8ZN8fuAz0TRYKoGsrIq5kLNHtm81KAqWSBORHIY0DpJmZZrwK/r2zFDOhFIAJDV47gJ6irV7dWf1TOFpKvULQ==
+  dependencies:
+    jsep "^0.3.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -2791,7 +2798,7 @@ js-yaml@3.14.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsep@^0.3.4:
+jsep@^0.3.0, jsep@^0.3.4:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/jsep/-/jsep-0.3.5.tgz#3fd79ebd92f6f434e4857d5272aaeef7d948264d"
   integrity sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==
@@ -4293,11 +4300,6 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-strict-event-emitter-types@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz#05e15549cb4da1694478a53543e4e2f4abcf277f"
-  integrity sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==
 
 "string-width@^1.0.2 || 2":
   version "2.1.1"


### PR DESCRIPTION
Bumps spectral and releases v0.2.4.

Somebody noticed that the new `defined` function was missing which got me wanting to make this PR.