### PR TITLE
chore: bump spectral to 5.8.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Stoplight <support@stoplight.io>",
   "dependencies": {
-    "@stoplight/spectral": "^5.6.0",
+    "@stoplight/spectral": "^5.8.0",
     "minimatch": "^3.0.4",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@stoplight/better-ajv-errors@0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.0.tgz#18bf69c2380a00b72e4bd5fb7247c5adf615795a"
-  integrity sha512-jA1i4J5HmCXMmZdZigdeEHpisFCGVg5QfK++ouxP58pxshATJ5G40U9uGec2vYnuR2MQnzWHAXYf0f8jvJhBwg==
+"@stoplight/better-ajv-errors@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/better-ajv-errors/-/better-ajv-errors-0.0.3.tgz#8d47a511aca89e0027cf748785910fbb25d7c54f"
+  integrity sha512-q3PoPiYZdzfJjQ+q6ifuLVFx3dBKRxW1OBGxnLAoDlamYb+GJUNiaSLB32L6OB4fi6h/TsY21lZB7y7aYFM7tQ==
   dependencies:
     jsonpointer "^4.0.1"
     leven "^3.1.0"
@@ -119,12 +119,12 @@
   resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.3.2.tgz#96e591496b72fde0f0cdae01a61d64f065bd9ede"
   integrity sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==
 
-"@stoplight/spectral@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.6.0.tgz#b69efc2d32bb7db5f165339a3131d9bb619c5e98"
-  integrity sha512-BLHAC/J56njpju3Z7TY9VMBbTxo4nY/WK7a3s5tYxIY6rOvNeS+qne3xK14qWnk4FS/gxAkVH9s1wZDWh/SVlw==
+"@stoplight/spectral@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/spectral/-/spectral-5.8.0.tgz#2ba242e74aaf521ab758e607e66dd938f6382bd2"
+  integrity sha512-KzcdC3qhxK9rKIipMJeviR+vlbVHBofCKqOnGEa73ZyYOpgn7YL5i9YEkVOMLO2vBfnLVGsRroTfa4KnRodjoA==
   dependencies:
-    "@stoplight/better-ajv-errors" "0.0.0"
+    "@stoplight/better-ajv-errors" "0.0.3"
     "@stoplight/json" "3.9.0"
     "@stoplight/json-ref-readers" "1.2.1"
     "@stoplight/json-ref-resolver" "3.1.0"
@@ -133,13 +133,13 @@
     "@stoplight/types" "^11.9.0"
     "@stoplight/yaml" "4.2.1"
     abort-controller "3.0.0"
-    ajv "6.12.2"
+    ajv "6.12.5"
     ajv-oai "1.2.0"
     blueimp-md5 "2.13.0"
     chalk "4.0.0"
     eol "0.9.1"
     expression-eval "3.1.2"
-    fast-glob "3.1.0"
+    fast-glob "3.2.4"
     jsonpath-plus "4.0.0"
     lodash "4.17.19"
     nanoid "2.1.11"
@@ -556,10 +556,10 @@ ajv-oai@1.2.0:
   dependencies:
     decimal.js "^10.2.0"
 
-ajv@6.12.2:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
-  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+ajv@6.12.5:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1955,18 +1955,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.0.tgz#77375a7e3e6f6fc9b18f061cddd28b8d1eec75ae"
-  integrity sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-
-fast-glob@^3.1.1:
+fast-glob@3.2.4, fast-glob@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==


### PR DESCRIPTION
This PR bumps spectral dependency and fixes https://github.com/stoplightio/vscode-spectral/issues/68

**Does this PR introduce a breaking change?**

- [x] No
