### PR TITLE
Move removing dependencies to inside settings check

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -299,9 +299,9 @@ function setupDocumentListener(): void {
   documents.onDidClose((event) => {
     resolveSettings(event.document).then((settings) => {
       const uri = event.document.uri;
-      documentSettings.delete(uri);
-      seenDependencies.delete(uri);
       if (settings.validate) {
+        documentSettings.delete(uri);
+        seenDependencies.delete(uri);
         // Clear any diagnostics associated with the document that closed.
         connection.sendDiagnostics({ uri: uri, diagnostics: [] });
       }


### PR DESCRIPTION
When changing dependent files, they are being removed as dependencies when the dependent file is being closed. This is causing the problem of them remaining even after the main file is closed. Moving the removal inside the check for `settings.validate` fixes this issue.

Fixes #205.

**Checklist**

- [X] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
